### PR TITLE
fix docs link to reference page

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,8 +12,8 @@ hero:
     alt: SankeyMakie
   actions:
     - theme: brand
-      text: Introduction
-      link: /introduction
+      text: Reference
+      link: /reference
     - theme: alt
       text: View on Github
       link: https://github.com/MakieOrg/SankeyMakie.jl


### PR DESCRIPTION
The highlighted button on the landing page currently points to https://makieorg.github.io/SankeyMakie.jl/dev/introduction, which does not exist.

I renamed the button to "Reference" and adjusted the link.